### PR TITLE
Fix python 3.6 and windows builds.

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,8 +12,8 @@ source:
     url: https://pypi.io/packages/source/j/jupyterlab/jupyterlab-{{ version }}.tar.gz
     sha256: {{ sha256 }}
 build:
-  number: 0
-  skip: True  # [py2k]
+  number: 1
+  skip: True  # [py<35]
   script: python -m pip install --no-deps --ignore-installed --install-option="--skip-npm" --verbose .
   entry_points:
     - jupyter-lab = jupyterlab.labapp:main
@@ -22,11 +22,11 @@ build:
 
 requirements:
   build:
-    - python >=3.5
+    - python
     - pip
     - nodejs >=8
   run:
-    - python >=3.5
+    - python
     - jupyterlab_server >=0.2.0,<0.3.0
     - notebook >=4.3.1
 test:


### PR DESCRIPTION
From @isuruf on the conda-forge gitter channel: https://gitter.im/conda-forge/conda-forge.github.io?at=5bbb8adb271506518dd861b7

> python matrix builds are used if you have just - python as a requirement.
> `- python >= 3.5` means conda-build can use any python version >= 3.5 as a run requirement, but what we actually want is the python version that it built against as the run requirement”

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a fork of the feedstock to propose changes
* [x] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/conda_smithy.html#how-to-re-render ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
