### PR TITLE
Add entry point for jlpm to fix Windows error

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,13 +12,14 @@ source:
     url: https://pypi.io/packages/source/j/jupyterlab/jupyterlab-{{ version }}.tar.gz
     sha256: {{ sha256 }}
 build:
-  number: 0
+  number: 1
   skip: True  # [py<35]
   script: python -m pip install --no-deps --ignore-installed --install-option="--skip-npm" --verbose .
   entry_points:
     - jupyter-lab = jupyterlab.labapp:main
     - jupyter-labextension = jupyterlab.labextensions:main
     - jupyter-labhub = jupyterlab.labhubapp:main
+    - jlpm = jupyterlab.jlpmapp:main
 
 requirements:
   build:


### PR DESCRIPTION
Checklist
* [x] Used a fork of the feedstock to propose changes
* [x] Bumped the build number (if the version is unchanged)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

`jlpm` entry point was not specified in the conda recipe. This prevents it to work on Windows as reported in https://github.com/jupyterlab/jupyterlab/issues/6972. But I do not know why it was working before as basically it worked up to 1.0.4. And since then, neither `jlpm` script nor the recipe were changed.

The fix has been tested locally.

The annoying fact is that the error happens in the appveyor ci but it was not detected:
https://ci.appveyor.com/project/conda-forge/jupyterlab-feedstock/builds/26761454/job/wfrfihnw5ey77vsu#L1285