### PR TITLE
JupyterLab 3.0.2 (with pip check, added maintainer)

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @afshin @blink1073 @ellisonbg @ian-r-rose @jasongrout @jochym @jtpio
+* @afshin @blink1073 @bollwyvl @ellisonbg @ian-r-rose @jasongrout @jochym @jtpio

--- a/README.md
+++ b/README.md
@@ -126,6 +126,7 @@ Feedstock Maintainers
 
 * [@afshin](https://github.com/afshin/)
 * [@blink1073](https://github.com/blink1073/)
+* [@bollwyvl](https://github.com/bollwyvl/)
 * [@ellisonbg](https://github.com/ellisonbg/)
 * [@ian-r-rose](https://github.com/ian-r-rose/)
 * [@jasongrout](https://github.com/jasongrout/)

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,15 +1,12 @@
-{% set version = "3.0.1" %}
-{% set sha256 = "72759e43d6063d4b3bf5bc4fa5ef72dd970bc43bdcb82d87affee73bbdb5be34" %}
-
+{% set version = "3.0.2" %}
 
 package:
   name: jupyterlab
   version: {{ version }}
 
 source:
-  fn: jupyterlab-{{ version }}.tar.gz
   url: https://pypi.io/packages/source/j/jupyterlab/jupyterlab-{{ version }}.tar.gz
-  sha256: {{ sha256 }}
+  sha256: 7e66b9a9c652869fc2ed069fc1eef3ca3b3879d082c432f08b4e6f1c8d97ff83
 build:
   noarch: python
   number: 0
@@ -22,27 +19,31 @@ build:
 
 requirements:
   host:
-    - python >=3.6
-    - pip
+    - jupyter-packaging >=0.7.3,<0.8.0
     - nodejs >=12
-    - jupyter-packaging
     - packaging
-  run:
+    - pip
     - python >=3.6
-    - jupyter_core
-    - jupyterlab_server >=2.0.0,<3.0.0
-    - jupyter_server >=1.1.0,<2.0.0
-    - nbclassic >=0.2.0,<0.3.0
-    - tornado >=6.1
+    - wheel
+  run:
+    - ipython
     - jinja2 >=2.10
+    - jupyter_core
+    - jupyter_server >=1.1.0,<2.0.0
+    - jupyterlab_server >=2.0.0,<3.0.0
+    - nbclassic >=0.2.0,<0.3.0
     - packaging
+    - python >=3.6
+    - tornado >=6.1.0
 
 test:
   requires:
     - nodejs >=12
+    - pip
   imports:
     - jupyterlab
   commands:
+    - pip check
     - jupyter lab --version
     - jlpm --version
     - jlpm versions
@@ -76,3 +77,4 @@ extra:
     - afshin
     - ellisonbg
     - jtpio
+    - bollwyvl


### PR DESCRIPTION
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.
  * [ ] well... kinda... https://github.com/jupyterlab/jupyterlab/pull/9519

Notes:
- Just so we get something going while the bot chews on the queue
- but while i'm at it...
  - [x] add `pip check`, 
  - [x] sync declared dependencies with upstream
  - [x] add myself as a maintainer :wave: :kissing_cat: 

Follow-on:  
  - [ ] it would be good to target automerge, but would feel more comfortable with that if there was at least some execution of the upstream testing done (probably not full browser tests)