### PR TITLE
[bot-experiment] Add bot PRs for all current branches, cache azure artifacts

### DIFF
--- a/.azure-pipelines/azure-pipelines-linux.yml
+++ b/.azure-pipelines/azure-pipelines-linux.yml
@@ -38,3 +38,16 @@ jobs:
       BINSTAR_TOKEN: $(BINSTAR_TOKEN)
       FEEDSTOCK_TOKEN: $(FEEDSTOCK_TOKEN)
       STAGING_BINSTAR_TOKEN: $(STAGING_BINSTAR_TOKEN)
+  - script: |
+        full_artifact_name="conda_artifacts_$(build.BuildId)_$(CONFIG)"
+        artifact_name=`echo "$full_artifact_name" | head -c 80`
+        echo "##vso[task.setVariable variable=ARTIFACT_NAME]$artifact_name"
+        if [ -d build_artifacts ]; then
+          echo "##vso[task.setVariable variable=CONDA_BLD_DIR_EXISTS]true"
+        fi
+    displayName: Check for conda build artifacts
+    condition: succeededOrFailed()
+
+  - publish: build_artifacts/
+    artifact: $(ARTIFACT_NAME)
+    condition: eq(variables.CONDA_BLD_DIR_EXISTS, 'true')

--- a/conda-forge.yml
+++ b/conda-forge.yml
@@ -1,3 +1,16 @@
 provider:
   win: azure
+
 conda_forge_output_validation: true
+
+azure:
+  # toggle for storing the conda build_artifacts directory (including the
+  # built packages) as an Azure pipeline artifact that can be downloaded
+  store_build_artifacts: true
+
+
+bot:
+  # any branches listed in this section will get bot migration PRs in addition
+  # to the default branch
+  abi_migration_branches:
+    - 2.x

--- a/conda-forge.yml
+++ b/conda-forge.yml
@@ -14,3 +14,5 @@ bot:
   # to the default branch
   abi_migration_branches:
     - 2.x
+    - rc
+    - rc-2.x


### PR DESCRIPTION
- maybe helps #173

This PR (once merged) should cause the bot to make PRs for branches:
- `2.x`
- `rc`
- `rc-2.x`

It will also upload the azure artifacts (but only on this branch) so they can be downloaded (from azure) if that is desirable. We could add that to the other branches as they have stuff, but not worth building right now

If this makes too many PRs, we can scale it back.

Not sure how it will play out, but would remove some manual processes.